### PR TITLE
feat(qb-policejob): add booking-room mugshot station

### DIFF
--- a/qb-mdt/README.md
+++ b/qb-mdt/README.md
@@ -86,8 +86,9 @@ Engineering constraints this resource is built around (they differ from FiveM):
 - Dispatch map is a placeholder grid — needs a top-down world image, two
   calibration coordinates and unit position sync.
 - No dispatch/all-units broadcast role yet (multi-channel voice).
-- Mugshot/BOLO photos render when a profile has an `image` URL; there is no
-  in-game capture source.
+- Profile photos come from the qb-policejob mugshot station (pushed through
+  `exports['qb-mdt']:SetProfileImage`); BOLO photos still need an `image` URL
+  set by hand.
 - Voice gating (mute-by-distance, PTT) still needs multiplayer testing.
 
 ## Development

--- a/qb-mdt/client/main.lua
+++ b/qb-mdt/client/main.lua
@@ -49,6 +49,12 @@ local function OpenMDT()
             return
         end
         isOpen = true
+        -- CCTV list comes from qb-policejob (single source of truth); pcall in
+        -- case that resource isn't running.
+        if data.role == 'police' then
+            local ok, cams = pcall(function() return exports['qb-policejob']:GetCameraList() end)
+            data.cameras = (ok and cams) or {}
+        end
         my_webui:BringToFront()
         my_webui:SetInputMode(1)
         my_webui:SendEvent('mdt:open', data)
@@ -151,6 +157,18 @@ end)
 
 my_webui:RegisterEventHandler('mdt:close', function()
     CloseMDT()
+end)
+
+my_webui:RegisterEventHandler('mdt:viewCamera', function(data)
+    -- JSON-string payload (nested objects don't survive hEvent JS->Lua).
+    if type(data) ~= 'table' or type(data.payload) ~= 'string' then return end
+    local ok, parsed = pcall(JSON.parse, data.payload)
+    local camId = ok and type(parsed) == 'table' and tonumber(parsed.id) or nil
+    if not camId then return end
+    -- The CCTV view is a full-screen takeover (view-target blend); close the
+    -- tablet first. Backspace exits the camera (qb-policejob behavior).
+    CloseMDT()
+    TriggerLocalClientEvent('qb-policejob:client:ActiveCamera', camId)
 end)
 
 my_webui:RegisterEventHandler('mdt:panic', function()

--- a/qb-mdt/html/app.js
+++ b/qb-mdt/html/app.js
@@ -63,6 +63,7 @@ const S = {
     // ui
     modal: null, toast: null, panic: null, dutyPick: "available",
     unitBoard: [],          // [{id, channel, occupants:[{citizenid,name}]}]
+    cameras: [],            // CCTV [{id,label,isOnline}] from qb-policejob
     myUnit: null,           // unit currently connected to (callsign + radio)
 };
 
@@ -144,11 +145,12 @@ const ICO = {
     reports: svg('<path d="M14 2H7a2 2 0 00-2 2v16a2 2 0 002 2h10a2 2 0 002-2V7z"/><path d="M14 2v5h5M9 13h6M9 17h6"/>'),
     bolo: svg('<path d="M2 12s3.6-7 10-7 10 7 10 7-3.6 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/>'),
     person: svg('<circle cx="12" cy="7.4" r="4.4" fill="currentColor" stroke="none"/><path d="M3.6 21.5c.8-4.7 4.3-7.1 8.4-7.1s7.6 2.4 8.4 7.1z" fill="currentColor" stroke="none"/>'),
+    cctv: svg('<rect x="2" y="5" width="13" height="7" rx="2"/><path d="M15 8.5l6-2.5v7l-6-2.5M6.5 12v4.5a2 2 0 002 2H12"/>'),
 };
 
 function navDef() {
     return S.role === "police"
-        ? [["dash", "DASHBOARD"], ["dispatch", "DISPATCH"], ["citizen", "CITIZENS"], ["vehicle", "VEHICLES"], ["reports", "REPORTS"], ["bolo", "BOLO BOARD"]]
+        ? [["dash", "DASHBOARD"], ["dispatch", "DISPATCH"], ["citizen", "CITIZENS"], ["vehicle", "VEHICLES"], ["reports", "REPORTS"], ["bolo", "BOLO BOARD"], ["cctv", "CCTV"]]
         : [["dash", "DASHBOARD"], ["dispatch", "DISPATCH"], ["citizen", "PATIENTS"], ["bolo", "ADVISORIES"]];
 }
 
@@ -431,6 +433,22 @@ function renderDash() {
     </div>`;
 }
 
+function renderCctv() {
+    const cards = S.cameras.map(c => `<div class="panel cctvcard">
+        <div class="cctvfeed">${ICO.cctv}<span class="mono fs11 dim2">FEED ${c.isOnline ? "STANDBY" : "LOST"}</span></div>
+        <div class="pad16">
+            <div class="fx ac jb"><span class="disp fs15 fw7">${esc(c.label)}</span><span class="pill ${c.isOnline ? "pok" : "pbad"}">${c.isOnline ? "ONLINE" : "OFFLINE"}</span></div>
+            <div class="mono fs12 dim2 mt8">CAM-${String(c.id).padStart(2, "0")} · 145.101.0.${c.id}</div>
+            <button class="btnp btn w100 mt12" data-act="viewCamera" data-arg="${c.id}" ${c.isOnline ? "" : "disabled"}>VIEW FEED</button>
+        </div>
+    </div>`).join("");
+    return `<div class="scr">
+        <div class="fx ac jb"><div><h1>CCTV</h1><div class="mono fs12 dim mt8">CITY SURVEILLANCE NETWORK · ${S.cameras.length} CAMERAS</div></div></div>
+        ${S.cameras.length ? `<div class="cctvgrid stag">${cards}</div>` : `<div class="empty">No cameras on the network</div>`}
+        <div class="mono fs12 dim2">Viewing a feed closes the terminal — press BACKSPACE on the feed to return, F5 to reopen.</div>
+    </div>`;
+}
+
 function renderDispatch() {
     const live = S.calls.filter(c => c.status !== "closed");
     const call = live.find(c => String(c.id) === String(S.callId)) || live[0];
@@ -525,7 +543,7 @@ function renderCitizen() {
         <div class="fx ac jb"><h1>${S.role === "ems" ? "Patient" : "Citizen"} Record</h1><span class="mono fs13 dim">${esc(c.citizenid)} ${c.online ? '· <span class="bok">IN CITY</span>' : ""}</span></div>
         <div class="citgrid">
             <div class="panel pad20 col gap16 oauto">
-                <div class="fx gap16"><div class="mug">${c.image ? `<img src="${esc(c.image)}" alt="">` : ICO.person}</div>
+                <div class="fx gap16"><div class="mug${c.image ? " zoomable" : ""}"${c.image ? ` data-act="viewPhoto" data-arg="${esc(c.image)}" title="Click to enlarge"` : ""}>${c.image ? `<img src="${esc(c.image)}" alt="">` : ICO.person}</div>
                     <div class="f1"><div class="disp fs26 fw7" style="line-height:1.15">${esc(name)}</div><div class="mono fs13 dim mt8">${esc(c.citizenid)}</div>
                     <div class="fx gap8 mt12 wrap">${flags}</div></div></div>
                 <div>
@@ -682,6 +700,11 @@ function renderModal() {
     if (!S.modal) return "";
     const { kind, data } = S.modal;
     let inner = "";
+    if (kind === "photo") {
+        // Lightbox: bare image, no form chrome. Backdrop click closes (.ovl
+        // handler); the image itself closes too.
+        return `<div class="ovl"><div class="photobox" data-act="closeModal"><img src="${esc(data.src)}" alt=""></div></div>`;
+    }
     if (kind === "bulletin") {
         inner = `<div class="disp fs22 fw7">Post Bulletin</div>
         <input id="mTitle" class="inp w100 mt16" placeholder="Title">
@@ -771,7 +794,7 @@ function render() {
     if (S.screen === "boot") inner = renderBoot();
     else if (S.screen === "login") inner = renderLogin();
     else {
-        const scr = { dash: renderDash, dispatch: renderDispatch, citizen: renderCitizen, vehicle: renderVehicle, reports: renderReports, bolo: renderBolo }[S.screen] || renderDash;
+        const scr = { dash: renderDash, dispatch: renderDispatch, citizen: renderCitizen, vehicle: renderVehicle, reports: renderReports, bolo: renderBolo, cctv: renderCctv }[S.screen] || renderDash;
         inner = `<div class="fx w100" style="height:100%">${renderSidebar()}<div class="col f1 ohide">${renderTopbar()}<div class="content">${scr()}</div></div></div>`;
     }
     stage.innerHTML = `<div class="gridbg"></div>${inner}<div id="overlays"><div id="modalHost"></div><div id="toastHost"></div><div id="panicHost"></div></div><div class="scanl"></div>`;
@@ -863,6 +886,10 @@ const ACTIONS = {
         // Nested objects don't survive hEvent JS->Lua — stringify, Lua parses (same as rpc()).
         if (call && call.coords) { hEvent("mdt:setWaypoint", { payload: JSON.stringify({ coords: call.coords, title: call.title }) }); toast("Waypoint set"); }
     },
+    viewCamera(arg) {
+        // Nested objects don't survive hEvent JS->Lua — stringify (rpc pattern).
+        hEvent("mdt:viewCamera", { payload: JSON.stringify({ id: Number(arg) }) });
+    },
     // reports
     openReport(arg) { openReport(arg ? Number(arg) : null); },
     closeReport() { S.report = null; render(); },
@@ -905,6 +932,7 @@ const ACTIONS = {
     },
     // warrants
     modalWarrant(arg) { openModal("warrant", { citizenid: arg }); },
+    viewPhoto(arg) { if (arg) openModal("photo", { src: arg }); },
     async submitWarrant() {
         const reason = (($("#mTitle") || {}).value || "").trim();
         const exp = ($("#mExp") || {}).value;
@@ -1104,6 +1132,7 @@ window.addEventListener("message", (event) => {
             S.unitBoard = toArr(payload.unitBoard);
             S.myUnit = (S.officer.callsign && S.officer.callsign !== "NO CALLSIGN") ? S.officer.callsign : null;
             S.penal = toArr(payload.penalCode);
+            S.cameras = toArr(payload.cameras);
             S.priorities = payload.priorities || {};
             S.statuses = toArr(payload.statuses);
             tablet.classList.remove("hidden", "closing");
@@ -1177,7 +1206,9 @@ if (IS_PREVIEW) {
             citizenid: "CIT88012", firstname: "Marcus", lastname: "Delgado", dob: "1989-03-14", gender: 0,
             nationality: "USA", phone: "555-0142", job: { label: "Civilian", grade: "Freelancer" }, gang: { label: "Vago Kings" },
             bloodtype: "O-", licences: { driver: false, weapon: false }, notes: "Known to frequent Dockside Row.",
-            flags: ["VIOLENT", "ARMED"], image: "", online: true,
+            flags: ["VIOLENT", "ARMED"], online: true,
+            // placeholder mugshot so the preview exercises the photo lightbox
+            image: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI3MjAiIGhlaWdodD0iOTAwIj48cmVjdCB3aWR0aD0iNzIwIiBoZWlnaHQ9IjkwMCIgZmlsbD0iIzhmOTU5ZCIvPjxnIGZpbGw9Im5vbmUiIHN0cm9rZT0iIzExMSIgc3Ryb2tlLXdpZHRoPSI2Ij48bGluZSB4MT0iMCIgeTE9IjkwIiB4Mj0iNzIwIiB5Mj0iOTAiLz48bGluZSB4MT0iMCIgeTE9IjE4MCIgeDI9IjcyMCIgeTI9IjE4MCIvPjxsaW5lIHgxPSIwIiB5MT0iMjcwIiB4Mj0iNzIwIiB5Mj0iMjcwIi8+PGxpbmUgeDE9IjAiIHkxPSIzNjAiIHgyPSI3MjAiIHkyPSIzNjAiLz48bGluZSB4MT0iMCIgeTE9IjQ1MCIgeDI9IjcyMCIgeTI9IjQ1MCIvPjxsaW5lIHgxPSIwIiB5MT0iNTQwIiB4Mj0iNzIwIiB5Mj0iNTQwIi8+PGxpbmUgeDE9IjAiIHkxPSI2MzAiIHgyPSI3MjAiIHkyPSI2MzAiLz48bGluZSB4MT0iMCIgeTE9IjcyMCIgeDI9IjcyMCIgeTI9IjcyMCIvPjxsaW5lIHgxPSIwIiB5MT0iODEwIiB4Mj0iNzIwIiB5Mj0iODEwIi8+PC9nPjxjaXJjbGUgY3g9IjM2MCIgY3k9IjMzMCIgcj0iMTEwIiBmaWxsPSIjYzlhMTg0Ii8+PHJlY3QgeD0iMjUwIiB5PSI0MzAiIHdpZHRoPSIyMjAiIGhlaWdodD0iMzAwIiByeD0iNjAiIGZpbGw9IiNkZmUzZTgiLz48L3N2Zz4=",
             vehicles: [{ plate: "KRT4402", vehicle: "Warrener GTS", garage: "downtown", state: 0, fuel: 80 }],
             convictions: [{ id: 1, charges: [{ code: "PR-06", label: "Armed Robbery", fine: 5000, sentence: 45 }], fine: 5000, sentence: 45, officer_name: "K. Reyes", created: "2026-07-02 21:40" }],
             warrants: [{ id: 12, reason: "Armed Robbery — PR-06", status: "active", author_name: "K. Reyes", created: "2026-07-02 22:00" }],
@@ -1241,6 +1272,11 @@ if (IS_PREVIEW) {
                 bulletins: [{ id: 1, title: "Vago Kings activity up 40% in Old Town", content: "Increased presence requested on the Dockside corridor between 20:00-04:00.", author_name: "Det. Ames", author_cid: "X", created: "2026-07-07 18:20" }],
                 units: demo.units,
                 unitBoard: demo.unitBoard,
+                cameras: [
+                    { id: 1, label: "9five Convenience", isOnline: true },
+                    { id: 2, label: "Jet Stop Fuel", isOnline: true },
+                    { id: 3, label: "Meridian Savings ATM", isOnline: false },
+                ],
                 penalCode: [
                     { category: "Offenses Against Persons", charges: [{ code: "P-01", label: "Assault", class: "misdemeanor", fine: 250, sentence: 10 }, { code: "P-05", label: "Murder", class: "felony", fine: 10000, sentence: 120 }] },
                     { category: "Offenses Against Property", charges: [{ code: "PR-06", label: "Armed Robbery", class: "felony", fine: 5000, sentence: 45 }] },

--- a/qb-mdt/html/style.css
+++ b/qb-mdt/html/style.css
@@ -209,3 +209,18 @@ select.inp { appearance: none; }
 .bologrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
 .ptgrid { display: grid; grid-template-columns: 330px 1fr; gap: 18px; flex: 1; min-height: 0; }
 .zgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.cctvgrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; align-content: start; }
+.cctvcard { overflow: hidden; }
+.cctvfeed { height: 130px; background: #0a101c; border-bottom: 1px solid #1c2740; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; color: #33455f; }
+.cctvfeed svg { width: 40px; height: 40px; }
+.btnp[disabled], .btn[disabled] { opacity: .35; pointer-events: none; }
+
+/* ── Citizen photo lightbox ──────────────────────────────────────────────── */
+.mug.zoomable { cursor: zoom-in; transition: border-color .12s; }
+.mug.zoomable:hover { border-color: var(--acc); }
+.photobox { cursor: zoom-out; animation: mIn .2s cubic-bezier(.2, .8, .2, 1); }
+.photobox img {
+    display: block; max-width: 60vw; max-height: 78vh;
+    border-radius: 12px; border: 1px solid #2c3a58;
+    box-shadow: 0 30px 80px rgba(0, 0, 0, .7);
+}

--- a/qb-mdt/server/dispatch.lua
+++ b/qb-mdt/server/dispatch.lua
@@ -429,6 +429,22 @@ RegisterServerEvent('qb-mdt:server:ptt', function(source, talking, voice)
     end
 end)
 
+-- ─────────────────────────── profile image ──────────────────────────────────
+-- The mugshot station lives in qb-policejob (capture, subject resolution,
+-- photo history — see qb-policejob/server/mugshot.lua). It pushes each new
+-- photo here so the citizen profile updates; any other resource may call
+-- this too (e.g. an ID card system).
+exports('qb-mdt', 'SetProfileImage', function(citizenid, url)
+    if type(citizenid) ~= 'string' or citizenid == '' then return false end
+    if type(url) ~= 'string' or url == '' then return false end
+    MDT.Execute(
+        [[INSERT INTO mdt_profiles (citizenid, image) VALUES (?, ?)
+          ON CONFLICT(citizenid) DO UPDATE SET image = excluded.image, updated = CURRENT_TIMESTAMP]],
+        { citizenid, url }
+    )
+    return true
+end)
+
 RegisterServerEvent('qb-mdt:server:panic', function(source, coords)
     local ok, err = pcall(function()
         local Player, role = MDT.GetContext(source)

--- a/qb-policejob/Client/evidence.lua
+++ b/qb-policejob/Client/evidence.lua
@@ -410,6 +410,7 @@ end
 
 function onShutdown()
     TriggerLocalClientEvent('qb-policejob:client:CloseCamera')
+    if PoliceMugshotTeardown then PoliceMugshotTeardown() end -- client/mugshot.lua
     unregisterWeaponFireListener()
     for kind, zones in pairs(EvidenceZones) do
         for id in pairs(zones) do

--- a/qb-policejob/README.md
+++ b/qb-policejob/README.md
@@ -1,0 +1,45 @@
+# qb-policejob
+
+Police job for HELIX/QBCore: duty, interactions, evidence, fingerprints, CCTV, helicopter camera, ANPR, vehicle impound, licenses, trackers, and a booking-room mugshot station.
+
+## Mugshot station
+
+Officers photograph a suspect at a booking-room tripod. The photo uploads to an image host and is stored per citizen; other resources read it through an export.
+
+How it works in game:
+
+1. An officer targets the tripod ("Take Mugshot", LEO only) and gets a live viewfinder rendered from a fixed camera aimed at the height chart.
+2. The suspect stands on the chart mark. The viewfinder shows their ID, name, DOB and gender once they are in frame, driven by a 1s server probe.
+3. The officer can zoom (1.0x to 2.5x), nudge and re-aim the camera, and control a studio light (on/off, intensity, color temperature) from the viewfinder, by mouse or keyboard. `E` takes the photo, `R` resets zoom, `Backspace` or `Esc` cancels.
+4. On capture the server records who is in frame at that moment, the PNG uploads in the background, and the photo is saved to that citizen with the photographing officer logged. If nobody is in frame, the officer is prompted for a citizen ID instead.
+
+The subject is found with a ray test along the camera's line of sight: the player closest to the lens within `corridorCm` of the sight line wins, so a person standing behind the suspect cannot end up in the record.
+
+### Reading mugshots from other resources
+
+```lua
+-- server: latest photo for a citizen, or nil
+local shot = exports['qb-policejob']:GetMugshot(citizenid)
+if shot then
+    print(shot.url, shot.taken)
+end
+```
+
+Every saved photo is also pushed to the MDT profile through `exports['qb-mdt']:SetProfileImage(citizenid, url)`. The call is wrapped in pcall, so servers without qb-mdt keep working and keep their full history in the `police_mugshots` table (citizen, URL, officer, timestamp; one row per photo).
+
+### Adding a station
+
+Run `/mugshotsetup` twice in game: once standing at the tripod facing the height chart, once standing on the chart mark. The command prints a finished station block for `Config.Mugshot.stations`:
+
+```lua
+{
+    interact = Vector(562173, 570672, 4665),  -- tripod target
+    camPos = Vector(562148, 570672, 4725),    -- lens position, at face height
+    camRot = Rotator(0, -179.5, 0),           -- lens rotation, facing the chart
+    stand = Vector(562013, 570678, 4654),     -- chart mark the suspect stands on
+    corridorCm = 100,                         -- sight-line half-width for subject detection
+    fov = 24,                                 -- frames head and shoulders at 1.6m
+},
+```
+
+Uploads go to the endpoint in `Config.Mugshot.imageApi` (FiveManage by default); set your own API key there.

--- a/qb-policejob/client/mugshot.lua
+++ b/qb-policejob/client/mugshot.lua
@@ -1,0 +1,478 @@
+-- qb-policejob mugshot station: tripod target -> live viewfinder (SceneCapture
+-- feed + WebUI chrome) -> E captures -> upload -> server resolves the subject
+-- (ray test) and stores the photo. Consumers read results via the server
+-- export GetMugshot(citizenid); qb-mdt is notified through its
+-- SetProfileImage export. Nothing here depends on the MDT.
+
+local active = nil        -- station config while the viewfinder is open
+local activeIndex = 0
+local sceneCap, camRoot, camFeed = nil, nil, nil
+local capComp = nil       -- USceneCaptureComponent2D (zoom = FOV change)
+local zoom = 1.0
+local probeTimer = nil    -- 1s subject probe while the viewfinder is open
+
+-- Studio light, spawned per session and torn down with the viewfinder.
+-- Intensity is clamped to 1000-30000: 30k already overexposes a subject at
+-- tripod distance, and the 10k default reads as even studio lighting.
+local light = {}          -- { actor, comp }
+local lightState = { on = true, intensity = 10000, temp = 'neutral' }
+local LIGHT_TEMPS = {
+    cool = { 0.80, 0.90, 1.00 },
+    neutral = { 1.00, 1.00, 1.00 },
+    warm = { 1.00, 0.86, 0.70 },
+}
+
+-- Adjustable camera pose (position + aim), reset to the station calibration
+local camPose = nil       -- { x, y, z, yaw, pitch }
+
+local function notify(text, kind)
+    TriggerLocalClientEvent('QBCore:Notify', text, kind or 'primary')
+end
+
+-- ─────────────────────────── WebUI bridge ───────────────────────────────────
+-- The viewfinder chrome lives in qb-policejob/html (mugshot.js) on the shared
+-- PoliceJobUI page (created in client/camera.lua, loads before this file).
+
+local function sendUI(event, payload)
+    if PoliceJobUI then PoliceJobUI:SendEvent(event, payload or {}) end
+end
+
+-- Focus = mouse on the HUD, player look parked. Action keybinds (E,
+-- Backspace, arrows, R) still fire while a WebUI holds focus.
+local function setFocus(focused)
+    if not PoliceJobUI then return end
+    if focused then
+        PoliceJobUI:BringToFront()
+        PoliceJobUI:SetInputMode(1)
+    else
+        PoliceJobUI:SetInputMode(0)
+    end
+end
+
+-- Everything the HUD renders about the rig, pushed after every control op
+local function pushState()
+    sendUI('mugshot:state', {
+        zoom = zoom,
+        lightAvailable = light.comp ~= nil,
+        lightOn = lightState.on,
+        lightIntensity = lightState.intensity,
+        lightTemp = lightState.temp,
+    })
+end
+
+-- ─────────────────────────── viewfinder ─────────────────────────────────────
+
+local function teardown()
+    if probeTimer then Timer.ClearInterval(probeTimer) probeTimer = nil end
+    if camRoot then camRoot:RemoveFromParent() end
+    if sceneCap and sceneCap.Object then sceneCap.Object:K2_DestroyActor() end
+    if light.actor then pcall(function() light.actor:K2_DestroyActor() end) end
+    light = {}
+    sceneCap, camRoot, camFeed, capComp = nil, nil, nil, nil
+    active = nil
+    activeIndex = 0
+    zoom = 1.0
+    camPose = nil
+    setFocus(false) -- give look/keys back to the game
+    sendUI('mugshot:close', {})
+end
+
+-- Called from client/evidence.lua's onShutdown (a second onShutdown global
+-- here would overwrite it and leak the WebUI).
+function PoliceMugshotTeardown()
+    teardown()
+end
+
+-- Zoom = narrower capture FOV. Clamped 1.0x–2.5x in 0.25 steps.
+local function applyZoom()
+    if not active or not capComp then return end
+    capComp.FOVAngle = (active.fov or 50) / zoom
+    pushState()
+end
+
+-- ─────────────────────────── studio light ───────────────────────────────────
+-- One spotlight at the lens aimed at the subject. Both spawns are pcall'd:
+-- if neither light class is exposed by the runtime, the HUD reports lighting
+-- as unavailable and everything else keeps working.
+
+local function applyLight()
+    if not light.comp then return end
+    pcall(function()
+        light.comp:SetVisibility(lightState.on, false)
+        light.comp:SetIntensity(lightState.intensity)
+        local t = LIGHT_TEMPS[lightState.temp] or LIGHT_TEMPS.neutral
+        light.comp:SetLightColor(LinearColor(t[1], t[2], t[3], 1.0))
+    end)
+end
+
+local function spawnLight(station)
+    -- The light reuses the camera's calibrated transform (camPos + camRot):
+    -- the SceneCapture faces the chart with it, so no aim math is needed.
+    -- (Avoid computing rotations with two-arg math.atan here — this runtime
+    -- ignores the second argument.)
+    local pos = station.camPos
+    -- Spotlight actors emit downward at identity rotation; +90 pitch tips the
+    -- beam forward along the camera yaw for a level frontal light at face
+    -- height.
+    local rot = Rotator(station.camRot.Pitch + 90, station.camRot.Yaw, 0)
+    local ok, actor = pcall(SpawnActor, UE.ASpotLight, pos, rot)
+    local compClass = UE.USpotLightComponent
+    if not ok or not actor then
+        ok, actor = pcall(SpawnActor, UE.APointLight, pos, Rotator(0, 0, 0))
+        compClass = UE.UPointLightComponent
+    end
+    if not ok or not actor then
+        print('[qb-policejob] mugshot light spawn failed — LIGHTING controls disabled')
+        return
+    end
+
+    light.actor = actor
+    local okc, comp = pcall(function() return actor:GetComponentByClass(compClass.StaticClass()) end)
+    light.comp = (okc and comp) or nil
+    if not light.comp then return end
+    pcall(function() light.comp:SetMobility(UE.EComponentMobility.Movable) end)
+    pcall(function()
+        light.comp:SetAttenuationRadius(1500)
+        -- wide soft cone: cover head + shoulders with falloff, not a hard disc
+        light.comp:SetOuterConeAngle(65) -- no-op on the point-light fallback
+        light.comp:SetInnerConeAngle(25)
+    end)
+    applyLight()
+end
+
+-- ─────────────────────────── camera trim ────────────────────────────────────
+
+local function applyCamPose()
+    if not sceneCap or not sceneCap.Object or not camPose then return end
+    pcall(function()
+        sceneCap.Object:K2_SetActorLocation(Vector(camPose.x, camPose.y, camPose.z), false, nil, false)
+        sceneCap.Object:K2_SetActorRotation(Rotator(camPose.pitch, camPose.yaw, 0), false)
+    end)
+end
+
+local function resetCamPose(station)
+    camPose = {
+        x = station.camPos.X, y = station.camPos.Y, z = station.camPos.Z,
+        yaw = station.camRot.Yaw, pitch = station.camRot.Pitch,
+    }
+end
+
+-- Move sideways relative to where the camera currently looks (frame-space)
+local function camStrafe(dist)
+    local rad = math.rad(camPose.yaw + 90)
+    camPose.x = camPose.x + math.cos(rad) * dist
+    camPose.y = camPose.y + math.sin(rad) * dist
+end
+
+-- Ask the server whether someone is in front of the camera; the result feeds
+-- the HUD's SUBJECT INFO panel + POSITION indicator.
+local function probeSubject()
+    if not active then return end
+    local index = activeIndex
+    TriggerCallback('policeMugshotProbe', function(result)
+        if not active or activeIndex ~= index then return end -- stale reply
+        sendUI('mugshot:subject', result or {})
+    end, index)
+end
+
+local function openViewfinder(index)
+    local station = Config.Mugshot.stations[index]
+    if not station then return end
+    if active then teardown() end
+
+    -- Fixed lens at the tripod aimed at the height chart (see qb-phone for the
+    -- SceneCapture/Widget pattern; portrait aspect suits a mugshot).
+    sceneCap = SceneCapture(
+        station.camPos, station.camRot,
+        720, 900,
+        SceneCaptureSource.FinalColorLDR,
+        false
+    )
+    capComp = sceneCap.Object:GetComponentByClass(UE.USceneCaptureComponent2D.StaticClass())
+    if capComp then capComp.FOVAngle = station.fov or 50 end
+
+    local character = GetPlayerPawn()
+    local vp = UE.UWidgetLayoutLibrary.GetViewportSize(character)
+    local sx, sy = vp.X / 2560, vp.Y / 1440
+
+    -- Centered preview panel — MUST stay in sync with the .mugHole rect in
+    -- html/mugshot.css (760x950 at a 2560x1440 design space): the WebUI HUD
+    -- draws the chrome, this UMG image is the feed inside its cutout.
+    local w, h = math.floor(760 * sx), math.floor(950 * sy)
+    camRoot = Widget(NativeWidget.CanvasPanel)
+    camRoot:AddToViewport()
+    camFeed = Widget(NativeWidget.Image)
+    camRoot:AddChild(camFeed)
+    -- SetCanvasLayout anchors the widget's center on the given position,
+    -- not its top-left. The HTML hole is centered on the viewport, so the
+    -- feed goes to the viewport center.
+    camFeed:SetCanvasLayout(
+        Vector2D(math.floor(vp.X / 2), math.floor(vp.Y / 2)),
+        Vector2D(w, h)
+    )
+    camFeed.innerWidget:SetBrushResourceObject(sceneCap.RenderTarget)
+
+    active = station
+    activeIndex = index
+    zoom = 1.0
+    resetCamPose(station)
+    spawnLight(station)
+
+    sendUI('mugshot:open', { stationIndex = index })
+    setFocus(true)
+    pushState()
+    probeSubject()
+    probeTimer = Timer.SetInterval(probeSubject, 1000)
+end
+
+-- ─────────────────────────── capture + upload ───────────────────────────────
+
+local function capture()
+    if not active or not sceneCap or not sceneCap.RenderTarget then return end
+    local stationIndex = activeIndex
+    local character = GetPlayerPawn()
+    if not character then teardown() return end
+
+    -- Freeze the subject now: the upload takes seconds, and the photo shows
+    -- whoever stood in frame at the shutter moment, not whoever happens to be
+    -- there when the URL comes back.
+    TriggerServerEvent('qb-policejob:server:mugshotBegin', stationIndex)
+
+    local saveDir = UE.UKismetSystemLibrary.GetProjectSavedDirectory() .. 'MugShots/'
+    local fileName = 'mug_' .. tostring(os.time()) .. '.png'
+    UE.UKismetRenderingLibrary.ExportRenderTarget(character, sceneCap.RenderTarget, saveDir, fileName)
+    teardown()
+    notify('Processing mugshot…', 'primary')
+
+    -- Detached curl upload: HTTP.Request corrupts binary PNGs, so the file
+    -- goes out through a background curl and the response file is polled.
+    local filePath = (saveDir .. fileName):gsub('\\', '/')
+    local responsePath = filePath .. '.json'
+    local winPath = filePath:gsub('/', '\\')
+    local winResponsePath = responsePath:gsub('/', '\\')
+    local cmd = 'start "" /b curl -s -X POST'
+        .. ' -F "file=@' .. winPath .. '"'
+        .. ' -H "Authorization: ' .. Config.Mugshot.imageApi.key .. '"'
+        .. ' "' .. Config.Mugshot.imageApi.url .. '"'
+        .. ' -o "' .. winResponsePath .. '"'
+    os.execute(cmd)
+
+    local attempts = 0
+    local function pollResponse()
+        attempts = attempts + 1
+        local f = io.open(responsePath, 'r')
+        if f then
+            local result = f:read('*all')
+            f:close()
+            os.remove(responsePath)
+            os.remove(filePath)
+            local url = nil
+            if result and result ~= '' then
+                local ok, parsed = pcall(JSON.parse, result)
+                url = ok and parsed and parsed.data and parsed.data.url
+            end
+            if url and url ~= '' then
+                TriggerServerEvent('qb-policejob:server:mugshot', stationIndex, url)
+            else
+                notify('Mugshot upload failed — photo not saved', 'error')
+            end
+        elseif attempts < 120 then -- 60s cap; cold uploads can take a while
+            Timer.SetTimeout(pollResponse, 500)
+        else
+            os.remove(filePath)
+            print('[qb-policejob] mugshot upload timed out waiting for ' .. responsePath)
+            notify('Mugshot upload timed out — photo not saved', 'error')
+        end
+    end
+    Timer.SetTimeout(pollResponse, 500)
+end
+
+-- ─────────────────────────── HUD control ops ────────────────────────────────
+-- Clicked buttons arrive as { op, value } from html/mugshot.js; the keyboard
+-- shortcuts below route through the same ops.
+
+local CAM_STEP, AIM_STEP = 8, 1.5 -- cm per nudge, degrees per aim tick
+
+local function control(op, value)
+    if not active then return end
+
+    if op == 'capture' then capture() return end
+    if op == 'cancel' then teardown() notify('Mugshot cancelled', 'error') return end
+
+    if op == 'zoomIn' then zoom = math.min(2.5, zoom + 0.25) applyZoom() return end
+    if op == 'zoomOut' then zoom = math.max(1.0, zoom - 0.25) applyZoom() return end
+    if op == 'zoomReset' then zoom = 1.0 applyZoom() return end
+
+    if op == 'lightToggle' then lightState.on = not lightState.on applyLight() pushState() return end
+    if op == 'lightUp' then lightState.intensity = math.min(30000, lightState.intensity + 3000) applyLight() pushState() return end
+    if op == 'lightDown' then lightState.intensity = math.max(1000, lightState.intensity - 3000) applyLight() pushState() return end
+    if op == 'lightTemp' and LIGHT_TEMPS[value] then lightState.temp = value applyLight() pushState() return end
+
+    if op == 'camLeft' then camStrafe(-CAM_STEP) applyCamPose() return end
+    if op == 'camRight' then camStrafe(CAM_STEP) applyCamPose() return end
+    if op == 'camUp' then camPose.z = camPose.z + CAM_STEP applyCamPose() return end
+    if op == 'camDown' then camPose.z = camPose.z - CAM_STEP applyCamPose() return end
+    if op == 'camYawL' then camPose.yaw = camPose.yaw - AIM_STEP applyCamPose() return end
+    if op == 'camYawR' then camPose.yaw = camPose.yaw + AIM_STEP applyCamPose() return end
+    if op == 'camPitchU' then camPose.pitch = math.min(25, camPose.pitch + AIM_STEP) applyCamPose() return end
+    if op == 'camPitchD' then camPose.pitch = math.max(-25, camPose.pitch - AIM_STEP) applyCamPose() return end
+    if op == 'camReset' then resetCamPose(active) applyCamPose() return end
+end
+
+if PoliceJobUI then
+    PoliceJobUI:RegisterEventHandler('mugshot:op', function(data)
+        if type(data) ~= 'table' or type(data.op) ~= 'string' then return end
+        control(data.op, data.value)
+    end)
+end
+
+-- ─────────────────────────── input ──────────────────────────────────────────
+-- Keyboard shortcuts mirror the HUD buttons; keybinds fire even while the
+-- WebUI holds focus.
+
+Input.BindKey('E', function()
+    if active then control('capture') end
+end, 'Released')
+
+Input.BindKey('Backspace', function()
+    if active then control('cancel') end
+end, 'Released')
+
+Input.BindKey('Up', function()
+    if active then control('zoomIn') end
+end, 'Released')
+
+Input.BindKey('Down', function()
+    if active then control('zoomOut') end
+end, 'Released')
+
+Input.BindKey('R', function()
+    if active then control('zoomReset') end
+end, 'Released')
+
+-- ─────────────────────────── manual-ID fallback ─────────────────────────────
+-- Server found nobody in front of the camera: ask for the citizenid by hand
+-- (also the solo-test path — type your own). The exported ShowInput can't
+-- yield across the package boundary, so use qb-input's async event bridge:
+-- the request carries replyEvent, the dialog result comes back on it.
+
+local manualUrl = nil -- photo URL held while the citizenid dialog is open
+
+RegisterClientEvent('qb-policejob:client:mugshotManualReply', function(dialog)
+    local url = manualUrl
+    manualUrl = nil
+    if not url then return end
+    if dialog and dialog.citizenid and dialog.citizenid ~= '' then
+        TriggerServerEvent('qb-policejob:server:mugshotManual', dialog.citizenid, url)
+    else
+        notify('Mugshot discarded — no citizen ID given', 'error')
+    end
+end)
+
+RegisterClientEvent('qb-policejob:client:mugshotManual', function(url)
+    if type(url) ~= 'string' or url == '' then return end
+    manualUrl = url
+    TriggerLocalClientEvent('qb-input:client:ShowMenuAsync', {
+        replyEvent = 'qb-policejob:client:mugshotManualReply',
+        header = 'Mugshot — no subject in frame',
+        submitText = 'Save',
+        inputs = {
+            {
+                type = 'text',
+                name = 'citizenid',
+                label = 'Citizen ID',
+                text = 'e.g. ABC12345',
+                isRequired = true,
+            },
+        },
+    })
+end)
+
+RegisterClientEvent('qb-policejob:client:mugshot', function(data)
+    local index = tonumber(data and data.stationIndex) or 1
+    openViewfinder(index)
+end)
+
+-- ─────────────────────────── target zones ───────────────────────────────────
+-- Zones must be registered AFTER the player is loaded — XRay focus detection
+-- doesn't pick up targets registered during package load.
+
+local zonesRegistered = false
+
+local function registerMugshotZones()
+    if zonesRegistered then return end
+    zonesRegistered = true
+    for i, station in ipairs(Config.Mugshot.stations) do
+        if station.interact.X ~= 0 or station.interact.Y ~= 0 then -- skip uncalibrated placeholders
+            -- targetoptions must be an ARRAY of option tables (#options is
+            -- checked in AddTargetEntity; a bare option map has length 0 and
+            -- silently skips Xray registration)
+            exports['qb-target']:AddSphereZone('PoliceMugshot_' .. i, station.interact, 0,
+                { distance = 250, useMesh = true },
+                { {
+                    type = 'client',
+                    event = 'qb-policejob:client:mugshot',
+                    icon = 'camera',
+                    label = 'Take Mugshot',
+                    jobType = 'leo',
+                    stationIndex = i,
+                } })
+        end
+    end
+end
+
+RegisterClientEvent('QBCore:Client:OnPlayerLoaded', function()
+    registerMugshotZones()
+end)
+
+-- Package reloads happen mid-session (no OnPlayerLoaded refire): register
+-- after a short delay if a character is already active.
+Timer.SetTimeout(function()
+    local ok, pd = pcall(function() return exports['qb-core']:GetPlayerData() end)
+    if ok and pd and pd.citizenid then registerMugshotZones() end
+end, 2000)
+
+-- ─────────────────────────── calibration helper ─────────────────────────────
+-- /mugshotsetup — prints the current pawn position + rotation for pasting into
+-- Config.Mugshot. Run once at the tripod facing the chart, once on the chart.
+
+local setupTripod = nil -- step 1 result held until step 2
+
+local HConsole = GetActorByTag('HConsole')
+if HConsole then
+    HConsole:RegisterCommand('mugshotsetup', 'Two-step Config.Mugshot calibration', nil, {
+        HWorld,
+        function()
+            local pawn = GetPlayerPawn()
+            if not pawn then return end
+            local c = GetEntityCoords(pawn)
+            local r = pawn:K2_GetActorRotation()
+
+            if not setupTripod then
+                -- STEP 1: standing AT the tripod, FACING the height chart
+                setupTripod = { x = c.X, y = c.Y, z = c.Z, yaw = r.Yaw }
+                print('[qb-policejob] mugshotsetup 1/2 — tripod saved.')
+                print('[qb-policejob] Now STAND ON THE CHART MARK (where the suspect poses) and run /mugshotsetup again.')
+                notify('Mugshot setup 1/2: tripod saved — stand on the chart mark, run again', 'primary')
+            else
+                -- STEP 2: standing ON the chart mark → print the finished block
+                print('[qb-policejob] mugshotsetup 2/2 — paste this into Config.Mugshot.stations:')
+                print(('        {'))
+                print(('            interact = Vector(%.0f, %.0f, %.0f),'):format(setupTripod.x, setupTripod.y, setupTripod.z))
+                -- camera: 25cm forward along facing (clears the tripod prop),
+                -- +60 up = subject face height (camera looks level)
+                local rad = math.rad(setupTripod.yaw)
+                local camX = setupTripod.x + math.cos(rad) * 25
+                local camY = setupTripod.y + math.sin(rad) * 25
+                print(('            camPos = Vector(%.0f, %.0f, %.0f),'):format(camX, camY, setupTripod.z + 60))
+                print(('            camRot = Rotator(0, %.1f, 0),'):format(setupTripod.yaw))
+                print(('            stand = Vector(%.0f, %.0f, %.0f),'):format(c.X, c.Y, c.Z))
+                print(('            corridorCm = 100,'))
+                print(('            fov = 24,'))
+                print(('        },'))
+                notify('Mugshot setup 2/2: config printed to console — paste into config.lua', 'success')
+                setupTripod = nil
+            end
+        end,
+    })
+end

--- a/qb-policejob/config.lua
+++ b/qb-policejob/config.lua
@@ -72,3 +72,33 @@ Config.CarItems = {
     { name = 'empty_evidence_bag', amount = 10, info = {}, type = 'item', slot = 2 },
     { name = 'police_stormram', amount = 1, info = {}, type = 'item', slot = 3 },
 }
+
+-- Mugshot stations. Officer targets the tripod (interact) -> live viewfinder
+-- from camPos/camRot aimed at the height chart -> E captures -> photo uploads
+-- and is stored in police_mugshots (latest per citizen readable by any
+-- resource via exports['qb-policejob']:GetMugshot). Subject = ray test along
+-- the camera sight line (camPos -> stand): the player CLOSEST to the lens
+-- within corridorCm of that line wins, like a raycast's first hit.
+-- Calibrate with /mugshotsetup in game: run it once standing AT the tripod
+-- facing the chart (gives interact/camPos/camRot) and once standing ON the
+-- chart mark (gives stand).
+Config.Mugshot = {
+    imageApi = {
+        url = 'https://api.fivemanage.com/api/v3/file',
+        key = 'Py4jfdWgiRLzTTboAofHBC2aoiCSfrar',
+    },
+    stations = {
+        { -- South Beach PD booking room
+            interact = Vector(562173, 570672, 4665),
+            -- camPos z = subject face height (camera looks level, so aim
+            -- height = camera height); fov 24 frames head + shoulders at the
+            -- 1.6m tripod-to-chart distance. X nudged 25cm toward the chart
+            -- so the lens clears the tripod prop.
+            camPos = Vector(562148, 570672, 4725),
+            camRot = Rotator(0, -179.5, 0),
+            stand = Vector(562013, 570678, 4654),
+            corridorCm = 100, -- sight-line half-width for the subject ray test
+            fov = 24,
+        },
+    },
+}

--- a/qb-policejob/html/index.html
+++ b/qb-policejob/html/index.html
@@ -3,6 +3,8 @@
     <head>
         <meta charset="utf-8" />
         <title>Police Job UI</title>
+        <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="mugshot.css" />
         <style>
             html,
             body {
@@ -268,6 +270,11 @@
             </div>
         </div>
 
+        <!-- Mugshot viewfinder chrome (client/mugshot.lua drives it; see mugshot.js).
+             Center hole must match the UMG feed rect: 760x950 in a 2560x1440 design space. -->
+        <div id="mugshotHud" class="hidden"></div>
+
         <script src="script.js"></script>
+        <script src="mugshot.js"></script>
     </body>
 </html>

--- a/qb-policejob/html/mugshot.css
+++ b/qb-policejob/html/mugshot.css
@@ -1,0 +1,129 @@
+/* qb-policejob mugshot viewfinder HUD. Self-contained: the shared
+   PoliceJobUI page has no CSS framework, so this file carries its own reset
+   bits and keyframes. */
+#mugshotHud.hidden { display: none !important; }
+#mugshotHud, #mugshotHud * { box-sizing: border-box; }
+@keyframes blip { 0%, 100% { opacity: 1; } 50% { opacity: .25; } }
+@keyframes mIn { from { opacity: 0; transform: scale(.97); } }
+
+/* ── Mugshot viewfinder HUD ───────────────────────────────────────────────
+   Fullscreen chrome around the UMG camera feed (client/mugshot.lua). The
+   feed is a 760x950 rect in a 2560x1440 design space, centered — the
+   .mugHole rect below MUST match it (29.6875vw x 65.9722vh). All critical
+   chrome sits OUTSIDE the hole in case the UMG feed draws above the WebUI;
+   only the cosmetic crosshair lives inside. Amber accent = camera mode. */
+#mugshotHud { position: fixed; inset: 0; z-index: 60; pointer-events: none; font-family: 'IBM Plex Sans', 'Segoe UI', sans-serif; color: #d7e2f2; }
+#mugshotHud .mugHole {
+    position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
+    width: 29.6875vw; height: 65.9722vh;
+    /* dim everything around the feed without touching the hole itself */
+    box-shadow: 0 0 0 200vmax rgba(2, 4, 8, .45);
+}
+/* corner brackets — drawn just outside the hole so the feed never covers them */
+#mugshotHud .mugCr { position: absolute; width: 34px; height: 34px; border: 3px solid #e8eef8; }
+#mugshotHud .mugCr.tl { top: -14px; left: -14px; border-right: 0; border-bottom: 0; }
+#mugshotHud .mugCr.tr { top: -14px; right: -14px; border-left: 0; border-bottom: 0; }
+#mugshotHud .mugCr.bl { bottom: -14px; left: -14px; border-right: 0; border-top: 0; }
+#mugshotHud .mugCr.br { bottom: -14px; right: -14px; border-left: 0; border-top: 0; }
+/* side ticks (amber) */
+#mugshotHud .mugTick { position: absolute; top: 50%; width: 26px; height: 3px; background: #ffb020; }
+#mugshotHud .mugTick.l { left: -40px; } #mugshotHud .mugTick.r { right: -40px; }
+/* header strip above the hole */
+#mugshotHud .mugHead {
+    position: absolute; left: 0; right: 0; bottom: 100%; margin-bottom: 10px;
+    text-align: center; padding: 10px 0 12px;
+    background: rgba(8, 11, 18, .88); border: 1px solid #232e45; border-radius: 8px;
+}
+#mugshotHud .mugHead h1 { margin: 0; font: 700 20px 'Rajdhani', sans-serif; letter-spacing: .12em; color: #ffb020; }
+#mugshotHud .mugHead p { margin: 3px 0 0; font-size: 12.5px; color: #8494ad; }
+/* crosshair (inside the hole — cosmetic only) */
+#mugshotHud .mugCross { position: absolute; left: 50%; top: 44%; width: 44px; height: 44px; transform: translate(-50%, -50%); opacity: .9; }
+#mugshotHud .mugCross:before, #mugshotHud .mugCross:after { content: ""; position: absolute; background: #ffffffcc; }
+#mugshotHud .mugCross:before { left: 50%; top: 0; width: 1.5px; height: 100%; transform: translateX(-50%); }
+#mugshotHud .mugCross:after { top: 50%; left: 0; height: 1.5px; width: 100%; transform: translateY(-50%); }
+/* zoom pill below the hole */
+#mugshotHud .mugZoom {
+    position: absolute; left: 50%; top: 100%; margin-top: 12px; transform: translateX(-50%);
+    display: flex; align-items: center; gap: 12px; padding: 7px 16px;
+    background: rgba(8, 11, 18, .88); border: 1px solid #232e45; border-radius: 999px;
+    font: 600 13px 'JetBrains Mono', monospace;
+}
+#mugshotHud .mugZoom .zval { color: #ffb020; min-width: 42px; text-align: center; }
+#mugshotHud .mugZoom .zkey { color: #8494ad; font-size: 11px; }
+/* flanking panels */
+#mugshotHud .mugPanel {
+    position: absolute; top: 50%; transform: translateY(-50%);
+    width: 300px; background: rgba(8, 11, 18, .88);
+    border: 1px solid #232e45; border-radius: 10px; padding: 16px 18px;
+}
+#mugshotHud .mugPanel.left { right: calc(50% + 14.84375vw + 60px); }
+#mugshotHud .mugPanel.right { left: calc(50% + 14.84375vw + 60px); }
+#mugshotHud .mugTitle { display: flex; align-items: center; gap: 10px; font: 700 16px 'Rajdhani', sans-serif; letter-spacing: .1em; }
+#mugshotHud .mugTitle svg { width: 26px; height: 26px; color: #ffb020; flex-shrink: 0; }
+#mugshotHud .mugStatus { display: flex; align-items: center; gap: 7px; margin: 8px 0 0; font: 600 11px 'Rajdhani', sans-serif; letter-spacing: .16em; color: #ffb020; }
+#mugshotHud .mugStatus .dot { width: 8px; height: 8px; border-radius: 50%; background: #ffb020; animation: blip 1.6s infinite; }
+#mugshotHud .mugStatus.locked { color: #2ed573; } #mugshotHud .mugStatus.locked .dot { background: #2ed573; }
+#mugshotHud .mugSec { margin-top: 16px; padding-top: 12px; border-top: 1px solid #1c2740; font: 700 12px 'Rajdhani', sans-serif; letter-spacing: .14em; color: #8494ad; }
+#mugshotHud .mugRow { display: flex; justify-content: space-between; align-items: baseline; margin-top: 9px; font-size: 13px; }
+#mugshotHud .mugRow .k { color: #8494ad; }
+#mugshotHud .mugRow .v { font-family: 'JetBrains Mono', monospace; font-size: 12.5px; color: #e8eef8; text-align: right; max-width: 170px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+#mugshotHud .mugRow .v.none { color: #5c6b85; }
+/* instruction list */
+#mugshotHud .mugIns { display: flex; align-items: center; gap: 10px; margin-top: 10px; padding: 8px 10px; background: #0d1322; border-radius: 6px; font-size: 12.5px; color: #c9d7ec; }
+#mugshotHud .mugIns svg { width: 16px; height: 16px; color: #ffb020; flex-shrink: 0; }
+/* quality meter */
+#mugshotHud .mugQ { display: flex; justify-content: space-between; align-items: center; margin-top: 10px; font-size: 12.5px; }
+#mugshotHud .mugQ .k { color: #8494ad; letter-spacing: .04em; }
+#mugshotHud .mugQ .v { font: 600 11.5px 'Rajdhani', sans-serif; letter-spacing: .12em; color: #2ed573; }
+#mugshotHud .mugQ .v.bad { color: #ff4757; }
+#mugshotHud .mugBar { display: flex; gap: 4px; margin-top: 5px; }
+#mugshotHud .mugBar i { flex: 1; height: 5px; border-radius: 2px; background: #2ed573; }
+#mugshotHud .mugBar.bad i { background: #253046; } #mugshotHud .mugBar.bad i:first-child { background: #ff4757; }
+/* bottom controls */
+#mugshotHud .mugCtl { position: absolute; left: 50%; bottom: 5.5vh; transform: translateX(-50%); display: flex; align-items: center; gap: 22px; }
+#mugshotHud .mugBtn { display: flex; align-items: center; gap: 10px; padding: 13px 22px; background: rgba(8, 11, 18, .88); border: 1px solid #232e45; border-radius: 8px; font: 600 13px 'Rajdhani', sans-serif; letter-spacing: .1em; color: #e8eef8; }
+#mugshotHud .mugShutter { width: 72px; height: 72px; border-radius: 50%; border: 3px solid #ffb020; background: rgba(8, 11, 18, .9); display: grid; place-items: center; }
+#mugshotHud .mugShutter svg { width: 30px; height: 30px; color: #fff; }
+#mugshotHud kbd { display: inline-grid; place-items: center; min-width: 24px; height: 24px; padding: 0 6px; background: #1a2337; border: 1px solid #2c3a58; border-bottom-width: 2px; border-radius: 5px; font: 600 11.5px 'JetBrains Mono', monospace; color: #ffb020; }
+#mugshotHud .mugCancel { position: absolute; left: 34px; bottom: 5.5vh; display: flex; align-items: center; gap: 10px; font: 600 13px 'Rajdhani', sans-serif; letter-spacing: .1em; color: #c9d7ec; }
+/* bottom-right hint card */
+#mugshotHud .mugHint { position: absolute; right: 34px; bottom: 5.5vh; max-width: 330px; padding: 13px 16px; background: rgba(8, 11, 18, .88); border: 1px solid #232e45; border-left: 3px solid #ffb020; border-radius: 8px; font-size: 12.5px; line-height: 1.45; color: #c9d7ec; }
+#mugshotHud .mugHint b { color: #ffb020; }
+#mugshotHud .mugHint .warn { color: #ff9a3d; }
+
+/* ── Mugshot HUD v3: clickable controls (WebUI holds focus in this mode) ── */
+#mugshotHud .mugPanel, #mugshotHud .mugZoom, #mugshotHud .mugCtl, #mugshotHud .mugCancel { pointer-events: auto; }
+#mugshotHud button { font-family: inherit; }
+#mugshotHud .mugBtn, #mugshotHud .mugShutter, #mugshotHud .mugCancel { cursor: pointer; }
+#mugshotHud .mugBtn:hover, #mugshotHud .mugCancel:hover { border-color: #ffb020; color: #ffb020; }
+#mugshotHud .mugShutter:hover { background: #241c0a; }
+#mugshotHud .mugShutter:active { transform: scale(.94); }
+#mugshotHud .mugCancel { background: rgba(8, 11, 18, .88); border: 1px solid #232e45; border-radius: 8px; padding: 11px 16px; }
+/* mini buttons (light / camera / zoom) */
+#mugshotHud .mugMini {
+    min-width: 30px; height: 26px; padding: 0 8px; cursor: pointer;
+    background: #1a2337; border: 1px solid #2c3a58; border-radius: 5px;
+    color: #e8eef8; font: 600 12px 'JetBrains Mono', monospace;
+    display: inline-grid; place-items: center;
+}
+#mugshotHud .mugMini:hover { border-color: #ffb020; color: #ffb020; }
+#mugshotHud .mugMini:active { transform: translateY(1px); }
+#mugshotHud .mugMini.on { background: #ffb020; border-color: #ffb020; color: #10131c; }
+#mugshotHud .mugMini.temp { flex: 1; font-size: 10.5px; letter-spacing: .08em; }
+#mugshotHud .mugMini.wide { width: 100%; font: 600 11px 'Rajdhani', sans-serif; letter-spacing: .12em; }
+#mugshotHud .mugMini.pwr { float: right; min-width: 40px; height: 20px; font-size: 10px; }
+#mugshotHud .mugCtlRow { display: flex; align-items: center; gap: 6px; margin-top: 9px; }
+#mugshotHud .mugCtlRow .clab { width: 38px; flex-shrink: 0; font: 700 10.5px 'Rajdhani', sans-serif; letter-spacing: .12em; color: #8494ad; }
+#mugshotHud .mugGauge { flex: 1; display: flex; gap: 3px; align-items: center; }
+#mugshotHud .mugGauge i { flex: 1; height: 8px; border-radius: 2px; background: #253046; }
+#mugshotHud .mugGauge i.on { background: #ffb020; }
+#mugshotHud .mugNote { margin-top: 8px; font-size: 11.5px; color: #5c6b85; }
+/* quality meter states */
+#mugshotHud .mugQ .v.warn { color: #ff9a3d; }
+#mugshotHud .mugBar i { background: #253046; }
+#mugshotHud .mugBar i.on { background: #2ed573; }
+#mugshotHud .mugBar.warn i.on { background: #ff9a3d; }
+#mugshotHud .mugBar.bad i.on { background: #ff4757; }
+/* zoom pill uses mini buttons now */
+#mugshotHud .mugZoom { padding: 5px 8px; gap: 8px; }
+

--- a/qb-policejob/html/mugshot.js
+++ b/qb-policejob/html/mugshot.js
@@ -1,0 +1,219 @@
+/* qb-policejob mugshot viewfinder HUD — chrome around the UMG camera feed
+   driven by client/mugshot.lua.
+   Bridge:
+     Lua -> JS : window 'message' { name, args:[payload] } — mugshot:open /
+                 mugshot:close / mugshot:subject / mugshot:state
+     JS -> Lua : hEvent('mugshot:op', { op, value }) (flat table: nested JS
+                 objects don't survive hEvent JS->Lua)
+   The WebUI holds input focus while the viewfinder is open, so buttons are
+   clickable; keyboard shortcuts fire game-side in parallel. */
+(function () {
+    "use strict";
+
+    var mugshotHud = document.getElementById("mugshotHud");
+    if (!mugshotHud) return;
+
+    var IS_PREVIEW = /[?&]preview\b/.test(location.search);
+    if (IS_PREVIEW && typeof window.hEvent === "undefined") {
+        window.hEvent = function (name, data) {
+            console.log("[hEvent stub]", name, data);
+            if (name === "mugshot:op" && window.__previewMugOp) window.__previewMugOp(data);
+        };
+    }
+
+    function esc(v) {
+        return String(v == null ? "" : v)
+            .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+    }
+    function svg(inner) {
+        return '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">' + inner + "</svg>";
+    }
+
+    var MUG = {
+        open: false, zoom: 1, subject: null,
+        lightAvailable: false, lightOn: true, lightIntensity: 10000, lightTemp: "neutral",
+    };
+
+    var MUG_ICO = {
+        camera: svg('<path d="M4 8h3.2l1.8-2.6h6L16.8 8H20a1 1 0 011 1v9.4a1 1 0 01-1 1H4a1 1 0 01-1-1V9a1 1 0 011-1z"/><circle cx="12" cy="13" r="3.4"/>'),
+        face: svg('<circle cx="12" cy="12" r="9"/><path d="M9 10h.01M15 10h.01M9 15.2c.9.8 1.9 1.2 3 1.2s2.1-.4 3-1.2"/>'),
+        neutral: svg('<circle cx="12" cy="12" r="9"/><path d="M9 10h.01M15 10h.01M9 15.4h6"/>'),
+        nohat: svg('<path d="M5 14c0-4 3.1-7 7-7s7 3 7 7"/><path d="M3 14h18M8 19l8-8"/>'),
+        light: svg('<circle cx="12" cy="12" r="4.2"/><path d="M12 3v2.4M12 18.6V21M3 12h2.4M18.6 12H21M5.6 5.6l1.7 1.7M16.7 16.7l1.7 1.7M18.4 5.6l-1.7 1.7M7.3 16.7l-1.7 1.7"/>'),
+        frame: svg('<path d="M4 8V5a1 1 0 011-1h3M16 4h3a1 1 0 011 1v3M20 16v3a1 1 0 01-1 1h-3M8 20H5a1 1 0 01-1-1v-3"/><circle cx="12" cy="12" r="3.4"/>'),
+    };
+
+    // Button op -> Lua (client/mugshot.lua control())
+    function mugOp(op, value) {
+        hEvent("mugshot:op", { op: op, value: value || "" });
+    }
+
+    // Real LIGHTING readout derived from the studio light state
+    function mugLightQuality() {
+        if (!MUG.lightAvailable) return { label: "GOOD", cls: "", fill: 6 }; // no light rig: cosmetic
+        if (!MUG.lightOn) return { label: "DARK", cls: "bad", fill: 1 };
+        var i = MUG.lightIntensity;
+        var fill = Math.max(1, Math.min(6, Math.round((i / 30000) * 6)));
+        if (i < 7000) return { label: "LOW", cls: "warn", fill: fill };
+        if (i > 19000) return { label: "HARSH", cls: "warn", fill: fill };
+        return { label: "GOOD", cls: "", fill: fill };
+    }
+
+    function mugZoomLabel() { return parseFloat(MUG.zoom.toFixed(2)) + "x"; }
+
+    function renderMugshotHud() {
+        if (!MUG.open) { mugshotHud.classList.add("hidden"); return; }
+        var s = MUG.subject;
+        var locked = !!s;
+        var ins = [
+            [MUG_ICO.face, "Have the subject face forward"],
+            [MUG_ICO.neutral, "Keep a neutral expression"],
+            [MUG_ICO.nohat, "Remove hats, glasses, masks"],
+            [MUG_ICO.light, "Ensure even lighting on face"],
+            [MUG_ICO.frame, "Center head within the frame"],
+        ].map(function (it) { return '<div class="mugIns">' + it[0] + "<span>" + it[1] + "</span></div>"; }).join("");
+        var row = function (k, v) {
+            return '<div class="mugRow"><span class="k">' + k + '</span><span class="v ' + (v ? "" : "none") + '">' + (v ? esc(v) : "—") + "</span></div>";
+        };
+        var meter = function (k, m) {
+            var bars = "";
+            for (var i = 0; i < 6; i++) bars += '<i class="' + (i < m.fill ? "on" : "") + '"></i>';
+            return '<div class="mugQ"><span class="k">' + k + '</span><span class="v ' + m.cls + '">' + m.label + "</span></div>" +
+                '<div class="mugBar ' + m.cls + '">' + bars + "</div>";
+        };
+        var lightQ = mugLightQuality();
+        var posQ = locked ? { label: "GOOD", cls: "", fill: 6 } : { label: "NO SUBJECT", cls: "bad", fill: 1 };
+        var btn = function (op, label, value) {
+            return '<button class="mugMini" data-mop="' + op + '"' + (value ? ' data-mval="' + value + '"' : "") + ">" + label + "</button>";
+        };
+        var temp = function (t, label) {
+            return '<button class="mugMini temp ' + (MUG.lightTemp === t ? "on" : "") + '" data-mop="lightTemp" data-mval="' + t + '">' + label + "</button>";
+        };
+
+        var gauge = "";
+        for (var g = 0; g < 10; g++) gauge += '<i class="' + (MUG.lightOn && g < Math.round(MUG.lightIntensity / 3000) ? "on" : "") + '"></i>';
+        var lighting = MUG.lightAvailable
+            ? '<div class="mugSec">LIGHTING <button class="mugMini pwr ' + (MUG.lightOn ? "on" : "") + '" data-mop="lightToggle">' + (MUG.lightOn ? "ON" : "OFF") + "</button></div>" +
+              '<div class="mugCtlRow">' + btn("lightDown", "&minus;") + '<div class="mugGauge">' + gauge + "</div>" + btn("lightUp", "+") + "</div>" +
+              '<div class="mugCtlRow">' + temp("cool", "COOL") + temp("neutral", "NEUTRAL") + temp("warm", "WARM") + "</div>"
+            : '<div class="mugSec">LIGHTING</div><div class="mugNote">Light rig unavailable on this station</div>';
+
+        mugshotHud.innerHTML =
+            '<div class="mugHole">' +
+                '<span class="mugCr tl"></span><span class="mugCr tr"></span><span class="mugCr bl"></span><span class="mugCr br"></span>' +
+                '<span class="mugTick l"></span><span class="mugTick r"></span>' +
+                '<div class="mugHead"><h1>POSITION SUBJECT</h1><p>Ensure the face is centered and clearly visible</p></div>' +
+                '<div class="mugCross"></div>' +
+                '<div class="mugZoom">' + btn("zoomOut", "&minus;") + '<span class="zval">' + mugZoomLabel() + "</span>" + btn("zoomIn", "+") + "</div>" +
+            "</div>" +
+            '<div class="mugPanel left">' +
+                '<div class="mugTitle">' + MUG_ICO.camera + "<span>MUGSHOT SYSTEM</span></div>" +
+                '<div class="mugStatus ' + (locked ? "locked" : "") + '"><span class="dot"></span>' + (locked ? "SUBJECT IN FRAME" : "READY — AWAITING SUBJECT") + "</div>" +
+                '<div class="mugSec">SUBJECT INFO</div>' +
+                row("ID", s && s.citizenid) + row("NAME", s && s.name) + row("DOB", s && s.dob) +
+                row("GENDER", s ? (Number(s.gender) === 1 ? "Female" : "Male") : null) +
+                lighting +
+                '<div class="mugSec">CAMERA</div>' +
+                '<div class="mugCtlRow"><span class="clab">MOVE</span>' + btn("camLeft", "&#9664;") + btn("camRight", "&#9654;") + btn("camUp", "&#9650;") + btn("camDown", "&#9660;") + "</div>" +
+                '<div class="mugCtlRow"><span class="clab">AIM</span>' + btn("camYawL", "&#10226;") + btn("camYawR", "&#10227;") + btn("camPitchU", "&#8963;") + btn("camPitchD", "&#8964;") + "</div>" +
+                '<div class="mugCtlRow"><button class="mugMini wide" data-mop="camReset">RESET CAMERA</button></div>' +
+            "</div>" +
+            '<div class="mugPanel right">' +
+                '<div class="mugSec" style="margin-top:0;padding-top:0;border-top:0">CAPTURE INSTRUCTIONS</div>' + ins +
+                '<div class="mugSec">PHOTO QUALITY</div>' +
+                meter("LIGHTING", lightQ) +
+                meter("FOCUS", { label: "GOOD", cls: "", fill: 6 }) +
+                meter("POSITION", posQ) +
+            "</div>" +
+            '<button class="mugCancel" data-mop="cancel"><kbd>&#9003;</kbd> CANCEL</button>' +
+            '<div class="mugCtl">' +
+                '<button class="mugBtn" data-mop="zoomReset"><kbd>R</kbd> RESET ZOOM</button>' +
+                '<button class="mugShutter" data-mop="capture">' + MUG_ICO.camera + "</button>" +
+                '<button class="mugBtn" data-mop="capture"><kbd>E</kbd> TAKE PHOTO</button>' +
+            "</div>" +
+            '<div class="mugHint"><b>Press [E]</b> or click the shutter to capture<br>' +
+                (locked
+                    ? "Photo saves to the record of <b>" + esc(s.name || s.citizenid) + "</b>"
+                    : '<span class="warn">No subject in frame</span> — you\'ll be asked for a Citizen ID after capture') +
+            "</div>";
+        mugshotHud.classList.remove("hidden");
+    }
+
+    mugshotHud.addEventListener("click", function (e) {
+        var el = e.target.closest("[data-mop]");
+        if (!el) return;
+        mugOp(el.dataset.mop, el.dataset.mval);
+    });
+
+    window.addEventListener("keydown", function (e) {
+        // The WebUI holds focus while the viewfinder is open, so Esc lands here.
+        if (e.key === "Escape" && MUG.open) mugOp("cancel");
+    });
+
+    window.addEventListener("message", function (event) {
+        var data = event.data || {};
+        var payload = (Array.isArray(data.args) && data.args[0]) || {};
+        switch (data.name) {
+            case "mugshot:open":
+                MUG.open = true; MUG.zoom = 1; MUG.subject = null;
+                renderMugshotHud();
+                break;
+            case "mugshot:close":
+                MUG.open = false;
+                renderMugshotHud();
+                break;
+            case "mugshot:subject":
+                MUG.subject = payload.subject || null;
+                if (MUG.open) renderMugshotHud();
+                break;
+            case "mugshot:state":
+                MUG.zoom = Number(payload.zoom) || 1;
+                MUG.lightAvailable = !!payload.lightAvailable;
+                MUG.lightOn = !!payload.lightOn;
+                MUG.lightIntensity = Number(payload.lightIntensity) || 10000;
+                MUG.lightTemp = payload.lightTemp || "neutral";
+                if (MUG.open) renderMugshotHud();
+                break;
+        }
+    });
+
+    // Browser preview harness: ?preview&mugshot — buttons run against a
+    // simulated Lua state machine. S toggles the subject, Backspace closes.
+    if (IS_PREVIEW && /[?&]mugshot\b/.test(location.search)) {
+        var demoSubject = { citizenid: "CIT88012", name: "Marcus Delgado", dob: "1989-03-14", gender: 0 };
+        document.body.style.background = "#3a3f46"; // stand-in for the game feed
+        var sim = { zoom: 1, lightAvailable: true, lightOn: true, lightIntensity: 10000, lightTemp: "neutral" };
+        var pushSim = function () {
+            window.postMessage({ name: "mugshot:state", args: [{ zoom: sim.zoom, lightAvailable: sim.lightAvailable, lightOn: sim.lightOn, lightIntensity: sim.lightIntensity, lightTemp: sim.lightTemp }] }, "*");
+        };
+        window.__previewMugOp = function (data) {
+            var op = data.op, value = data.value;
+            if (op === "cancel") { window.postMessage({ name: "mugshot:close", args: [{}] }, "*"); return; }
+            if (op === "capture") { console.log("[preview] capture!"); return; }
+            if (op === "zoomIn") sim.zoom = Math.min(2.5, sim.zoom + 0.25);
+            if (op === "zoomOut") sim.zoom = Math.max(1, sim.zoom - 0.25);
+            if (op === "zoomReset") sim.zoom = 1;
+            if (op === "lightToggle") sim.lightOn = !sim.lightOn;
+            if (op === "lightUp") sim.lightIntensity = Math.min(30000, sim.lightIntensity + 3000);
+            if (op === "lightDown") sim.lightIntensity = Math.max(1000, sim.lightIntensity - 3000);
+            if (op === "lightTemp") sim.lightTemp = value;
+            pushSim();
+        };
+        setTimeout(function () {
+            window.postMessage({ name: "mugshot:open", args: [{ stationIndex: 1 }] }, "*");
+            pushSim();
+            setTimeout(function () {
+                window.postMessage({ name: "mugshot:subject", args: [{ ok: true, subject: demoSubject }] }, "*");
+            }, 2500);
+        }, 200);
+        window.addEventListener("keydown", function (e) {
+            if (!MUG.open) return;
+            if (e.key === "ArrowUp") mugOp("zoomIn");
+            if (e.key === "ArrowDown") mugOp("zoomOut");
+            if (e.key.toLowerCase() === "r") mugOp("zoomReset");
+            if (e.key.toLowerCase() === "s") window.postMessage({ name: "mugshot:subject", args: [MUG.subject ? { ok: true } : { ok: true, subject: demoSubject }] }, "*");
+            if (e.key === "Backspace") mugOp("cancel");
+        });
+    }
+})();

--- a/qb-policejob/package.json
+++ b/qb-policejob/package.json
@@ -11,7 +11,8 @@
         "client/anpr.lua",
         "client/evidence.lua",
         "client/objects.lua",
-        "client/tracker.lua"
+        "client/tracker.lua",
+        "client/mugshot.lua"
     ],
     "server": [
         "server/main.lua",
@@ -19,6 +20,7 @@
         "server/interactions.lua",
         "server/evidence.lua",
         "server/objects.lua",
-        "server/vehicle.lua"
+        "server/vehicle.lua",
+        "server/mugshot.lua"
     ]
 }

--- a/qb-policejob/server/mugshot.lua
+++ b/qb-policejob/server/mugshot.lua
@@ -1,0 +1,205 @@
+-- qb-policejob mugshot server: subject resolution (ray test), photo storage,
+-- and the result contract for other resources:
+--   exports['qb-policejob']:GetMugshot(citizenid) -> { url, taken } | nil
+-- On every saved photo the MDT (if running) is updated through its
+-- exports['qb-mdt']:SetProfileImage — pcall'd, so servers without the MDT
+-- still keep full mugshot history here.
+
+local function DbExecute(sql, params)
+    return exports['qb-core']:DatabaseAction('Execute', sql, params)
+end
+
+local function DbSelect(sql, params)
+    return exports['qb-core']:DatabaseAction('Select', sql, params)
+end
+
+DbExecute([[
+    CREATE TABLE IF NOT EXISTS police_mugshots (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        citizenid TEXT NOT NULL,
+        url TEXT NOT NULL,
+        officer_cid TEXT,
+        officer_name TEXT,
+        created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+]])
+DbExecute('CREATE INDEX IF NOT EXISTS idx_police_mugshots_cid ON police_mugshots (citizenid, id)')
+
+--- Validates the caller is a LEO. Duty is not required: the tripod target
+--- already gates who can open the station.
+--- @return Player|nil
+local function GetOfficer(source)
+    local Player = exports['qb-core']:GetPlayer(source)
+    local job = Player and Player.PlayerData.job
+    if not job or job.type ~= 'leo' then return nil end
+    return Player
+end
+
+-- ─────────────────────────── result contract ────────────────────────────────
+
+--- Latest mugshot for a citizen (any resource: ID cards, MDT, prison intake).
+exports('qb-policejob', 'GetMugshot', function(citizenid)
+    if type(citizenid) ~= 'string' or citizenid == '' then return nil end
+    local rows = DbSelect(
+        'SELECT url, created FROM police_mugshots WHERE citizenid = ? ORDER BY id DESC LIMIT 1',
+        { citizenid }
+    )
+    local row = rows and rows[1]
+    if not row then return nil end
+    return { url = row.url, taken = row.created }
+end)
+
+local function saveMugshot(Player, citizenid, url, name)
+    local oinfo = Player.PlayerData.charinfo or {}
+    DbExecute(
+        'INSERT INTO police_mugshots (citizenid, url, officer_cid, officer_name) VALUES (?, ?, ?, ?)',
+        { citizenid, url, Player.PlayerData.citizenid, ((oinfo.firstname or '') .. ' ' .. (oinfo.lastname or '')) }
+    )
+    -- Notify the MDT so the citizen profile photo updates immediately;
+    -- pcall'd because the MDT is optional.
+    pcall(function() exports['qb-mdt']:SetProfileImage(citizenid, url) end)
+    TriggerClientEvent(Player.PlayerData.source, 'QBCore:Notify',
+        ('Mugshot saved — %s (%s)'):format(name, citizenid), 'success')
+end
+
+-- ─────────────────────────── subject resolution ─────────────────────────────
+-- Who is in front of the camera? Ray test along the camera's line of sight
+-- (camPos -> stand: the lens aims at the chart mark by construction, so no
+-- rotator math needed). Each candidate is projected onto that axis; accept
+-- players inside the view corridor — forward of the lens, not past the wall
+-- behind the chart, within `corridorCm` laterally — and take the one CLOSEST
+-- to the lens, like a real raycast's first hit.
+-- The photographing officer is NOT excluded: at the tripod they sit behind
+-- the lens (fwd < 30) and never match, but an officer stepping in front of
+-- the camera is a valid subject — that's also the solo-test path.
+local function findMugshotSubject(station)
+    -- unit forward vector, camera -> chart (2D: booking rooms are flat)
+    local fx, fy = station.stand.X - station.camPos.X, station.stand.Y - station.camPos.Y
+    local standDist = math.sqrt(fx * fx + fy * fy)
+    if standDist < 1 then return nil end -- degenerate calibration
+    fx, fy = fx / standDist, fy / standDist
+
+    local maxFwd = standDist + 200            -- small margin past the mark
+    local maxLat = station.corridorCm or 100  -- half-width of the sight line
+    local best, bestFwd = nil, maxFwd
+    for _, p in pairs(GetAllPlayers()) do
+        local Subject = exports['qb-core']:GetPlayer(p)
+        if Subject then
+            local pawn = GetPlayerPawn(p)
+            local c = pawn and GetEntityCoords(pawn) or nil
+            if c then
+                local dx, dy = c.X - station.camPos.X, c.Y - station.camPos.Y
+                local fwd = dx * fx + dy * fy               -- distance along the ray
+                local lat = math.abs(dx * fy - dy * fx)     -- perpendicular offset
+                if fwd > 30 and fwd < bestFwd and lat <= maxLat then
+                    best, bestFwd = Subject, fwd
+                end
+            end
+        end
+    end
+    return best
+end
+
+-- Live viewfinder probe: is someone in front of the camera right now? Polled
+-- ~1/s by client/mugshot.lua while the viewfinder is open; feeds the HUD's
+-- subject panel + POSITION indicator. The callback name must be a plain
+-- identifier: the engine silently drops callback names containing a colon.
+RegisterCallback('policeMugshotProbe', function(source, stationIndex)
+    if not GetOfficer(source) then return { ok = false } end
+    local station = Config.Mugshot.stations[tonumber(stationIndex) or 0]
+    if not station then return { ok = false } end
+
+    local best = findMugshotSubject(station)
+    if not best then return { ok = true } end -- no subject in frame
+
+    local info = best.PlayerData.charinfo or {}
+    return {
+        ok = true,
+        subject = {
+            citizenid = best.PlayerData.citizenid,
+            name = ((info.firstname or '') .. ' ' .. (info.lastname or '')),
+            dob = info.birthdate or '',
+            gender = tonumber(info.gender) or 0,
+        },
+    }
+end)
+
+-- The shutter moment: snapshot who is in frame right now. The upload takes
+-- seconds and the subject may leave the corridor before the URL comes back;
+-- the photo shows whoever stood there when E was pressed, so that's who it
+-- saves to. Snapshots expire after 120s (the upload poll gives up at 60s).
+local pendingSubjects = {} -- [officer source] = { citizenid, name, t }
+
+RegisterServerEvent('qb-policejob:server:mugshotBegin', function(source, stationIndex)
+    local Player = GetOfficer(source)
+    if not Player then return end
+    local station = Config.Mugshot.stations[tonumber(stationIndex) or 0]
+    if not station then return end
+
+    local best = findMugshotSubject(station)
+    if not best then
+        pendingSubjects[source] = nil
+        return
+    end
+    local info = best.PlayerData.charinfo or {}
+    pendingSubjects[source] = {
+        citizenid = best.PlayerData.citizenid,
+        name = ((info.firstname or '') .. ' ' .. (info.lastname or '')),
+        t = os.time(),
+    }
+end)
+
+-- Upload finished (client/mugshot.lua); save the photo to the subject frozen
+-- at shutter time, falling back to a live re-scan, then to the manual prompt.
+RegisterServerEvent('qb-policejob:server:mugshot', function(source, stationIndex, url)
+    local Player = GetOfficer(source)
+    if not Player then return end
+    if type(url) ~= 'string' or url == '' then return end
+
+    local station = Config.Mugshot.stations[tonumber(stationIndex) or 0]
+    if not station then return end
+
+    local pending = pendingSubjects[source]
+    pendingSubjects[source] = nil
+    if pending and os.time() - pending.t <= 120 then
+        saveMugshot(Player, pending.citizenid, url, pending.name)
+        return
+    end
+
+    local best = findMugshotSubject(station)
+
+    -- Nobody in frame: hand the URL back to the officer's client, which
+    -- prompts for a citizenid (qb-input) and replies via mugshotManual below.
+    if not best then
+        TriggerClientEvent(Player.PlayerData.source, 'qb-policejob:client:mugshotManual', url)
+        return
+    end
+
+    local info = best.PlayerData.charinfo or {}
+    local name = ((info.firstname or '') .. ' ' .. (info.lastname or ''))
+    saveMugshot(Player, best.PlayerData.citizenid, url, name)
+end)
+
+-- Officer typed a citizenid after no subject was found in frame.
+RegisterServerEvent('qb-policejob:server:mugshotManual', function(source, citizenid, url)
+    local Player = GetOfficer(source)
+    if not Player then return end
+    if type(url) ~= 'string' or url == '' then return end
+    citizenid = type(citizenid) == 'string' and citizenid:gsub('%s', ''):upper() or ''
+    if citizenid == '' then return end
+
+    local rows = DbSelect('SELECT citizenid, charinfo FROM players WHERE citizenid = ?', { citizenid })
+    local row = rows and rows[1]
+    if not row then
+        TriggerClientEvent(Player.PlayerData.source, 'QBCore:Notify', 'Unknown citizen ID: ' .. citizenid, 'error')
+        return
+    end
+
+    local info = {}
+    if type(row.charinfo) == 'string' and row.charinfo ~= '' then
+        local ok, parsed = pcall(JSON.parse, row.charinfo)
+        if ok and type(parsed) == 'table' then info = parsed end
+    end
+    local name = ((info.firstname or '') .. ' ' .. (info.lastname or ''))
+    saveMugshot(Player, row.citizenid, url, name)
+end)


### PR DESCRIPTION
- Live viewfinder at the booking tripod: SceneCapture feed with WebUI chrome, zoom (1.0x-2.5x), camera nudge/aim controls, and a tunable studio light (on/off, intensity, color temperature)
- Subject detection by ray test along the camera sight line; the player closest to the lens wins, frozen at shutter time so slow uploads still save to the right person; manual citizen ID prompt when nobody is in frame
- Photos upload to FiveManage and persist per citizen in the new police_mugshots table; other resources read the latest photo via exports['qb-policejob']:GetMugshot(citizenid)
- qb-mdt consumes results through its new SetProfileImage export and gains a click-to-enlarge photo lightbox on citizen records
- qb-mdt CCTV tab: camera grid fed by the GetCameraList export, viewing a feed hands off to qb-policejob's camera
- /mugshotsetup prints a paste-ready station block for config.lua

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hypersonic-laboratories/codesmith/qbcore-rp/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786615685&installation_id=136299171&pr_number=15&repository=hypersonic-laboratories%2Fqbcore-rp&return_to=https%3A%2F%2Fgithub.com%2Fhypersonic-laboratories%2Fqbcore-rp%2Fpull%2F15&signature=08cac482ea04d7e6612a5bd82d1bdef07ff9a2e0fda0032f2bde4c4f47b2818f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->